### PR TITLE
fix(s3): ensure s3api calls always output json

### DIFF
--- a/lua/s3edit/s3.lua
+++ b/lua/s3edit/s3.lua
@@ -4,7 +4,7 @@ local sys = require("s3edit.system")
 --- Gets the Bucket Names from S3
 ---@return table a list of bucket names
 M.get_bucket_names = function()
-    local result = sys.make_system_call("aws s3api list-buckets")
+    local result = sys.make_system_call("aws s3api list-buckets --output json")
     if result == nil then
         return {}
     end
@@ -23,7 +23,7 @@ end
 ---@param bucket string the bucket to search
 ---@return table a list of objects
 M.get_objects = function(bucket)
-    local result = sys.make_system_call("aws s3api list-objects --bucket " .. bucket)
+    local result = sys.make_system_call("aws s3api list-objects --bucket " .. bucket .. " --output json")
     if result == nil then
         return {}
     end

--- a/lua/tests/s3_spec.lua
+++ b/lua/tests/s3_spec.lua
@@ -10,7 +10,7 @@ describe("get_bucket_names", function()
         local result = s3.get_bucket_names()
 
         assert.are.same({}, result)
-        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-buckets")
+        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-buckets --output json")
     end)
 
     it("should parse the bucket names", function()
@@ -39,7 +39,7 @@ describe("get_bucket_names", function()
 
         assert.are.same("bucket1", result[1])
         assert.are.same("bucket2", result[2])
-        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-buckets")
+        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-buckets --output json")
     end)
 end)
 
@@ -51,7 +51,7 @@ describe("get_objects", function()
         local result = s3.get_objects("my_bucket")
 
         assert.are.same({}, result)
-        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket")
+        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket --output json")
     end)
 
     it("should parse the objects", function()
@@ -89,7 +89,7 @@ describe("get_objects", function()
 
         assert.are.same("key1", result[1])
         assert.are.same("path/key2", result[2])
-        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket")
+        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket --output json")
     end)
 
     it("should return empty when no objects are found", function()
@@ -101,7 +101,7 @@ describe("get_objects", function()
         local result = s3.get_objects("my_bucket")
         assert.are.same({}, result)
 
-        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket")
+        assert.stub(mock_sys.make_system_call).was_called_with("aws s3api list-objects --bucket my_bucket --output json")
     end)
 end)
 

--- a/makefile
+++ b/makefile
@@ -2,7 +2,7 @@ run:
 	nvim --cmd "set rtp+=./" --cmd 'lua require("s3edit").setup()' -o lua/s3edit/init.lua
 
 test:
-	nvim --cmd "set rtp+=./" --headless -c "PlenaryBustedDirectory lua/tests/ { minimal_init = 'lua/tests/setup.vim' }"
+	nvim --cmd "set rtp+=./" --headless -c "PlenaryBustedDirectory lua/tests/"
 
 help:
 	nvim --cmd "set rtp+=./" --cmd 'h s3edit'


### PR DESCRIPTION
## Summary 

Ensure that internal `aws s3api` calls always produce `json` output irrespective of user settings 

Closes  #6 

## Changes

- Update `list-buckets` and `list-objects`  calls to always produce json output
    - [`s3api` Documentation](https://docs.aws.amazon.com/cli/latest/reference/s3api/list-buckets.html#global-options)
- Minor amendment to `test` command in `makefile` to stop Plenary from [freezing](https://github.com/nvim-lua/plenary.nvim/issues/319) 
